### PR TITLE
購入機能の実装

### DIFF
--- a/app/assets/javascripts/purchases.coffee
+++ b/app/assets/javascripts/purchases.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/_mixin.scss
+++ b/app/assets/stylesheets/_mixin.scss
@@ -2,3 +2,55 @@
   width: 700px;
   float: right;
 }
+
+@mixin wallpaper{
+  margin-left: 65px;
+  margin-right: 65px;
+}
+
+@mixin full-header{
+  height: 128px;
+  margin:0 auto;
+  width: 700px;
+  text-align: center;
+  .header-logo{
+    height: 100px;
+  }
+}
+
+@mixin full-content{
+  background-color: #fff;
+  width: 700px;
+  margin: 0 auto;
+}
+
+@mixin full-content-top{
+  padding: 32px 16px;
+  font-size: 22px;
+  border-bottom: 1px solid #f5f5f5;
+  text-align: center;
+}
+
+@mixin full-footer{
+  padding-top: 40px;
+  margin: 0;
+  color: #000;
+  text-align: center;
+  ul{
+    padding:0px;
+    height:30px;
+  }
+  .nav-list{
+    display: inline-block;
+    text-align: center;
+    font-size: 12px;
+    margin: 0 0 0 16px;
+    .user-link{
+      color: #333;
+    }
+  }
+  .footer-icon{
+    height: 80px;
+    margin: 40px auto 0;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,4 +12,5 @@
 @import "./modules/new-form";
 @import "./modules/user-side";
 @import "./modules/user-bought-list";
-@import "./modules/card"
+@import "./modules/card";
+@import "./modules/purchase";

--- a/app/assets/stylesheets/modules/_purchase.scss
+++ b/app/assets/stylesheets/modules/_purchase.scss
@@ -1,0 +1,94 @@
+.purchase{
+  @include wallpaper;
+  &__header{
+    @include full-header;
+  }
+  &__content{
+    @include full-content;
+    &__top{
+      @include full-content-top;
+    }
+    &__main{
+      padding: 24px 12.5% 0;
+      text-align: center;
+      &__inner{
+        max-width: 320px;
+        margin: 0 auto;
+        .purchase-item-box{
+          display: flex;
+          .purchase-item-image{
+            width: 64px;
+          }
+          .purchase-item-name{
+            width: calc(100% - 80px);
+            margin: 0 0 0 16px;
+            text-align: left;
+          }
+        }
+        .parchase-main-text{
+          margin: 0 0 0 8px;
+          font-weight: 400;
+        }
+        .purchase-btn{
+          background-color: #ccc;
+        }
+        .purchase-btn.active{
+          background-color: $mrcrRed;
+          color: #fff;
+        }
+        .purchase-price-box{
+          width: 100%;
+          .purchase-price{
+            display: table;
+            width: 100%;
+            font-size: 18px;
+            .purchase-buy-cell{
+              text-align: right;
+              padding: 16px 0;
+              display: table-cell;
+            }
+            .purchase-buy-cell:first-child {
+              text-align: left;
+              padding: 16px 0;
+            }
+          }
+          &__inner{
+            margin: 16px 0;
+          }
+        }
+      }
+    }
+    &__address{
+      border-top: 1px solid #f5f5f5;
+      padding: 24px 12.5% 0;
+      margin: 40px 0 0;
+      font-size: 14px;
+      &__inner{
+        max-width: 320px;
+        margin: 0 auto;
+        .purchase-text{
+          margin: 8px 0 0;
+          line-height: 1.4;
+        }
+      }
+    }
+    &__card{
+      border-top: 1px solid #f5f5f5;
+      padding: 24px 12.5% 40px;
+      margin: 40px 0 0;
+      font-size: 14px;
+      &__inner{
+        max-width: 320px;
+        margin: 0 auto;
+        .purchase-text{
+          margin: 8px 0 0;
+          line-height: 1.4;
+        }
+      }
+    }
+
+  }
+  &__footer{
+    @include full-footer;
+  }
+}

--- a/app/assets/stylesheets/modules/_user-common.scss
+++ b/app/assets/stylesheets/modules/_user-common.scss
@@ -16,6 +16,10 @@ li{
   color: $mrcrFColor;
 }
 
+.F-white{
+  color: #fff;
+}
+
 .F-gray{
   color: #888;
 }
@@ -68,5 +72,5 @@ li{
 
 .user_errors_message{
   font-size: 14px;
-  color: $mrcrRed
+  color: $mrcrRed;
 }

--- a/app/assets/stylesheets/purchases.scss
+++ b/app/assets/stylesheets/purchases.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the purchases controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -1,0 +1,52 @@
+class PurchasesController < ApplicationController
+
+  require 'payjp'
+
+  def show
+    @item = Item.find(params[:id])
+    @image = Image.find_by(item_id: @item.id)
+    card = Card.find_by(user_id: current_user.id)
+    #テーブルからpayjpの顧客IDを検索
+    if card.blank?
+      #登録された情報がない場合にカード登録画面に移動
+      redirect_to controller: "cards", action: "new"
+    else
+      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+      #保管した顧客IDでpayjpから情報取得
+      customer = Payjp::Customer.retrieve(card.customer_id)
+      #保管したカードIDでpayjpから情報取得、カード情報表示のためインスタンス変数に代入
+      @default_card_information = customer.cards.retrieve(card.card_id)
+      @card_brand = @default_card_information.brand
+      @exp_month = @default_card_information.exp_month.to_s
+      @exp_year = @default_card_information.exp_year.to_s.slice(2,3)
+      case @card_brand
+      when "Visa"
+        @card_brand_url = "visa.png"
+      when "JCB"
+        @card_brand_url = "jcbcard.png"
+      when "MasterCard"
+        @card_brand_url = "mastercard.png"
+      when "American Express"
+        @card_brand_url = "axcard.png"
+      when "Diners Club"
+        @card_brand_url = "dinersclub.png"
+      when "Discover"
+        @card_brand_url = "discover.png"
+      end
+    end
+  end
+
+  def pay
+    item = Item.find(params[:id])
+    card = Card.find_by(user_id: current_user.id)
+    Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
+    Payjp::Charge.create(
+      amount: item.price, #支払金額
+      customer: card.customer_id, #顧客ID
+      currency: 'jpy', #日本円
+    )
+    item.update(buyer_id: current_user.id)
+    redirect_to action: 'done' #完了画面に移動
+  end
+
+end

--- a/app/helpers/purchases_helper.rb
+++ b/app/helpers/purchases_helper.rb
@@ -1,0 +1,2 @@
+module PurchasesHelper
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,7 +1,6 @@
 class Item < ApplicationRecord
-
-  belongs_to :user, class_name: 'User', foreign_key: 'salar_id', optional: true
-  belongs_to :user, class_name: 'User', foreign_key: 'buyer_id', optional: true
+  belongs_to :saler, class_name: 'User'
+  belongs_to :buyer, class_name: 'User'
   belongs_to :user, class_name: 'User', foreign_key: 'shipped_saler_id', optional: true
   belongs_to :user, class_name: 'User', foreign_key: 'received_buyer_id', optional: true
   belongs_to :category

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -119,7 +119,7 @@
             送料込み
           </span>
         </div>  
-        <a class="item__buy-btn" href="#">購入画面に進む</a>
+        <%= link_to "購入画面に進む", purchase_path(@item.id),{class:"item__buy-btn"}%>
         <div class="item-description">
           <p class="item-description__inner">
             <%= @item.explanation%>

--- a/app/views/layouts/mypage/_user-side.haml
+++ b/app/views/layouts/mypage/_user-side.haml
@@ -35,7 +35,7 @@
           = icon "fas", "chevron-right",class:"other-icon next-icon"
       %li.user-info-list
         .user-info-various
-          = link_to '購入した商品-取引中', purchase_path
+          = link_to '購入した商品-取引中', '#'
           = icon "fas", "chevron-right",class:"other-icon next-icon"
       %li.user-info-list
         .user-info-various

--- a/app/views/purchases/done.haml
+++ b/app/views/purchases/done.haml
@@ -1,0 +1,32 @@
+.new-form
+  .new-form-box
+    .new-form-box__header
+      = image_tag "mrcr-logo.png",class:"login-logo"
+    .new-form-box__main
+      .new-form-box__main__top
+        %h3.top-text
+          購入完了
+      .new-form-box__main__form                              
+        .new-form-box__main__bottom
+          %p
+            ありがとうございます。
+          %p
+            商品を購入しました。
+          .form-group
+            .other-btn.form-next-btn
+              = link_to "トップへ戻る", "/", class:"F-white"
+            
+    .new-box__footer
+      .new-box__footer__nav
+        %ul
+          %li.new-nav-list
+            %a{href:"/"}
+              プライバシーポリシー
+          %li.new-nav-list
+            %a{href:"/"}
+              メルカリ利用規約
+          %li.new-nav-list
+            %a{href:"/"}
+              特定商取引に関する規約
+      .new-box__footer__icon
+        = image_tag 'mrcr-footer-icon.png',class:"new-footer-icon"

--- a/app/views/purchases/show.haml
+++ b/app/views/purchases/show.haml
@@ -1,0 +1,87 @@
+
+.purchase
+  .purchase__header
+    = image_tag "mrcr-logo.png",class:"header-logo"
+  .purchase__content
+    .purchase__content__top
+      %h3.F-bold
+        購入内容の確認
+    .purchase__content__main
+      .purchase__content__main__inner
+        .purchase-item-box
+          =image_tag "#{@image.images_url}", class: "purchase-item-image"
+          %p.purchase-item-name.F-bold
+            = @item.name
+        .purchase-price-box
+          .purchase-price-box__inner
+            %p.purchase-item-price
+              = "¥" + number_with_delimiter(@item.price)
+              %span.item__price__tax
+                (税込)
+              %span.purchase-main-text
+                送料込み
+          .other-btn.purchase-btn.point-btn
+            ポイントはありません
+          %ul
+            %li.purchase-price
+              .purchase-buy-cell.F-bold
+                支払い金額
+              .purchase-buy-cell.F-bold
+                = "¥" + number_with_delimiter(@item.price)
+                %span.item__price__tax
+                  (税込)
+            = form_tag(action: :pay, method: :post) do
+              = hidden_field_tag :id, @item.id
+              = submit_tag "購入する",class:"other-btn purchase-btn buy-btn active"
+
+    .purchase__content__address
+      .purchase__content__address__inner 
+        %p.purchase-text.F-bold
+          配送先
+        %p.purchase-text
+          = "〒"+  current_user.address.postal_code.to_s.insert(3, "-")
+          %br
+          = current_user.address.prefecture + current_user.address.city + current_user.address.street_number
+          -if current_user.address.building_name
+            %br
+            = current_user.address.building_name
+          %br
+            = current_user.family_name + current_user.first_name
+        .text-right
+          = link_to "変更する",edit_user_address_path(current_user.id, current_user.address.id),class:"form-bottom-text-link"
+          %span.F-bold.form-bottom-text-link
+            >
+    .purchase__content__card
+      .purchase__content__card__inner
+        %p.purchase-text.F-bold
+          支払い方法
+        %p.purchase-text
+          - if @default_card_information.blank?
+            %br /
+          - else
+            %ul.card-list
+              %li
+                = image_tag "#{@card_brand_url}", class:"card-img"
+              %li
+                = "**** **** **** " + @default_card_information.last4
+              %li
+                = @exp_month + " / " + @exp_year
+        .text-right
+          = link_to "変更する",cards_path,class:"form-bottom-text-link"
+          %span.F-bold.form-bottom-text-link
+            >
+            
+  .purchase__footer
+    .purchase__footer__nav
+      %ul
+        %li.nav-list
+          %a{href:"#"}
+            プライバシーポリシー
+        %li.nav-list
+          %a{href:"#"}
+            メルカリ利用規約
+        %li.nav-list
+          %a{href:"#"}
+            特定商取引に関する規約
+    .purchase__footer__icon
+      = image_tag 'mrcr-footer-icon.png',class:"footer-icon"

--- a/app/views/signup/done.html.haml
+++ b/app/views/signup/done.html.haml
@@ -36,7 +36,7 @@
             会員登録が完了しました。
           .form-group
             .other-btn.form-next-btn
-              = link_to "メルカリを始める", "/"
+              = link_to "メルカリを始める", "/", class:"F-white"
             
     .new-box__footer
       .new-box__footer__nav

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,15 @@ end
     end
   end
   resources :mypage, only: [:edit, :update]
-  
+
+  resources :purchases do
+    collection do
+      get 'show/:item_id', to: 'purchases#show'
+      post 'pay', to: 'purchases#pay'
+      get 'done', to: 'purchases#done'
+    end
+  end
+
   get "items/index" => "items#index"
   get "items/show" => "items#show"
   get "items/delete" => "items#delete"
@@ -43,7 +51,7 @@ end
   # マイページ
   get 'logout' => 'users#logout'
   get 'mypage' => 'users#show'
-get 'notification' =>'mypage#notification'
+  get 'notification' =>'mypage#notification'
   get 'todo' => 'mypage#todo'
   get 'purchase' => 'mypage#purchase'
   get 'purchased' => 'mypage#purchased'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,9 +22,8 @@ end
   end
   resources :mypage, only: [:edit, :update]
 
-  resources :purchases do
+  resources :purchases, only: [:show] do
     collection do
-      get 'show/:item_id', to: 'purchases#show'
       post 'pay', to: 'purchases#pay'
       get 'done', to: 'purchases#done'
     end

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe PurchasesController, type: :controller do
+
+end

--- a/spec/helpers/purchases_helper_spec.rb
+++ b/spec/helpers/purchases_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the PurchasesHelper. For example:
+#
+# describe PurchasesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe PurchasesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# What 
・pay.jpを使って購入機能を実装する
・purchases_controller（購入専用）を追加
　上記 controller内で、cardとitemを使って購入アクションを追加する
・item#showからlink_toでparamsを取得→特定のitemを探す
・カード情報がない場合は、cards#newへとばす
・購入はpayアクションで実装
（Payjp::Charge.createを使うことで支払い機能が実装できる）
・paramsは、hidden_field_tagを使ってitem.idを飛ばしてます。
・購入完了後、itemのbuyer_idにcurrent_userをいれる
・購入後はpurchases#doneへとばす

※buyer_idに値が入ったときの購入制限はまだです。

TO　湯藤さん
item#showの
"購入画面に進む"のリンク先を変更してます